### PR TITLE
Snyk auto fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 poetry==1.6.1
-pip==23.2.1
+pip==23.3
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.17 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
⠋ Running `snyk test` for /home/runner/work/shifter-jupyterlab/shifter-jupyterlab
► Running `snyk test` for /home/runner/work/shifter-jupyterlab/shifter-jupyterlab
- Looking for supported Python items

✔ Looking for supported Python items
- Looking for supported Python items

✔ Looking for supported Python items
⠋ Processing 1 pyproject.toml items⠋ Processing 2 requirements.txt items✔ Processed 2 requirements.txt items
- Checking poetry version
⚠️ Could not detect poetry version, proceeding anyway. Some operations may fail.
- Fixing pyproject.toml 1/1
✔ Processed 1 pyproject.toml items

 ✖ No successful fixes


Unresolved items:

  pyproject.toml
  x Failed to pin werkzeug from 2.2.3 to 3.0.1
  Reason:  No fixes could be applied.
  Tip:     Try running `poetry add werkzeug==3.0.1`

Summary:

  1 items were not fixed

  5 issues: 3 Medium | 2 Low
  1 issues are fixable
  

Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io